### PR TITLE
Refactor Evaluator.applyOp

### DIFF
--- a/src/main/java/calculator/CalculatorValue.java
+++ b/src/main/java/calculator/CalculatorValue.java
@@ -10,6 +10,8 @@ public abstract class CalculatorValue implements Expression {
 
     protected CalculatorValue(String strValue, int accuracy, boolean canInteract) {
         this.strValue = strValue;
+        this.canInteract = canInteract;
+        this.accuracyLevel = accuracy;
     }
 
     public void accept(Visitor v) {

--- a/src/main/java/calculator/ComputableExpression.java
+++ b/src/main/java/calculator/ComputableExpression.java
@@ -1,0 +1,45 @@
+package calculator;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.stream.Stream;
+
+public abstract class ComputableExpression {
+
+    protected String funcName;
+
+    public CalculatorValue op(CalculatorValue... args) throws InvocationTargetException {
+        CalculatorValue most_accurate_item = Arrays.stream(args).max((o1, o2) -> o2.accuracyLevel - o1.accuracyLevel).get();
+
+        Class targetClass = most_accurate_item.getClass();
+        String convert_fun_name = "to" + targetClass.getName().substring(targetClass.getName().lastIndexOf(".") + 1);
+
+        final Exception[] exception = new Exception[1];
+        try {
+            Stream<Object> streamConvertedArgs = Arrays.stream(args).map(i -> {
+                try {
+                    return i.getClass().getMethod(convert_fun_name).invoke(i);
+                } catch (IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
+                    exception[0] = e;
+                }
+                return null;
+            });
+            if (exception[0] != null)
+                throw exception[0];
+
+            Object[] convertedArgs = streamConvertedArgs.toArray();
+
+            Method fun = null;
+
+            fun = this.getClass().getMethod(funcName, Collections.nCopies(args.length, targetClass).toArray(new Class[args.length]));
+            return (CalculatorValue) fun.invoke(this, convertedArgs);
+        } catch (InvocationTargetException e) {
+            throw e;
+        } catch (Exception error) {
+            error.printStackTrace();
+        }
+        return null;
+    }
+}

--- a/src/main/java/calculator/Function.java
+++ b/src/main/java/calculator/Function.java
@@ -3,14 +3,10 @@ package calculator;
 import visitor.EvaluatorException;
 import visitor.Visitor;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.lang.reflect.InvocationTargetException;
 
-/**
- * TODO EXPERIMENTAL
- * TO complete
- */
-public abstract class Function implements Expression{
+
+public abstract class Function extends ComputableExpression implements Expression{
 
     public Expression arg;
 
@@ -19,11 +15,16 @@ public abstract class Function implements Expression{
             throw new IllegalConstruction(); }
         else {
             this.arg = arg;
+            funcName = "apply";
         }
     }
 
     public Expression getArg() {
         return arg;
+    }
+
+    public CalculatorValue apply(CalculatorValue ... args) throws InvocationTargetException{
+        return op(args);
     }
 
     @Override
@@ -39,7 +40,7 @@ public abstract class Function implements Expression{
 
     @Override
     public Integer countOps() {
-        return arg.countOps();
+        return 1+arg.countOps();
     }
 
     @Override

--- a/src/main/java/calculator/Main.java
+++ b/src/main/java/calculator/Main.java
@@ -77,6 +77,7 @@ public class Main {
 		System.out.println("Formatted result: " + res.toHumanFormat("hours"));
 		System.out.println("Formatted result: " + res.toHumanFormat("Minutes"));
 		System.out.println("Formatted result: " + res.toHumanFormat("SECONDS"));
+		System.out.println("");
 
 		List<Expression> params7 = new ArrayList<>();
 		Collections.addAll(params7, new IntegerNumber(5), new RationalNumber(1, 2));

--- a/src/main/java/calculator/Operation.java
+++ b/src/main/java/calculator/Operation.java
@@ -3,12 +3,17 @@ package calculator;
 import visitor.EvaluatorException;
 import visitor.Visitor;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.stream.Stream;
 
-public abstract class Operation implements Expression {
+public abstract class Operation extends ComputableExpression implements Expression {
     public List<Expression> args;
     protected String symbol;
     protected int neutral; // the neutral element of the operation (e.g. 1 for *, 0 for +)
@@ -21,6 +26,7 @@ public abstract class Operation implements Expression {
             throw new IllegalConstruction();
         } else {
             args = new ArrayList<>(elist);
+            funcName = "op";
         }
     }
 

--- a/src/main/java/visitor/Evaluator.java
+++ b/src/main/java/visitor/Evaluator.java
@@ -1,13 +1,16 @@
 package visitor;
 
-import calculator.CalculatorValue;
-import calculator.Expression;
-import calculator.Function;
-import calculator.Operation;
+import calculator.*;
 
+import java.lang.reflect.Array;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class Evaluator extends Visitor {
 
@@ -17,6 +20,18 @@ public class Evaluator extends Visitor {
 
     public void visit(CalculatorValue v){
         computedValue = v;
+    }
+
+    @Override
+    public void visit(Function f) throws EvaluatorException {
+        CalculatorValue evaluatedArg;
+        f.arg.accept(this);
+        evaluatedArg = computedValue;
+        try {
+            computedValue = f.apply(evaluatedArg);
+        } catch (InvocationTargetException e) {
+            throw new EvaluatorException("Impossible to evaluate the expression: "+e.getCause().getMessage(), f);
+        }
     }
 
     public void visit(Operation o) throws EvaluatorException {
@@ -29,97 +44,14 @@ public class Evaluator extends Visitor {
         //second loop to accummulate all the evaluated subresults
         CalculatorValue temp = evaluatedArgs.get(0);
         int max = evaluatedArgs.size();
-        CalculatorValue evaluated;
         for(int counter=1; counter<max; counter++) {
             try {
-                //temp = o.op(temp, evaluatedArgs.get(counter));
-                evaluated = evaluatedArgs.get(counter);
-                if((temp.getAccuracyLevel()>=evaluated.getAccuracyLevel()) || (temp.canInteract() && evaluated.canInteract())){
-                    temp = applyOp(evaluated,temp,o, true);
-                }else if(temp.getAccuracyLevel()<evaluated.getAccuracyLevel()){
-                    temp = applyOp(temp, evaluated,o, false);
-                }else{
-                    throw new EvaluatorException("cannot apply an operation between "+temp.toString()+" and "+
-                            evaluated.toString(), o);
-                }
-
-            }catch (ArithmeticException e){
-                // If a problem is encountered during the evaluation, throw a EvaluatorException
-                throw new EvaluatorException("Impossible to evaluate the operation: "+e.getMessage(), o);
-            } catch (InvocationTargetException e) {
-                throw new EvaluatorException("Impossible to evaluate the expression: "+e.getMessage(), o);
+                temp = o.op(temp,evaluatedArgs.get(counter));
+            }catch (InvocationTargetException e) {
+                throw new EvaluatorException("Impossible to evaluate the expression: "+e.getCause().getMessage(), o);
             }
         }
         // store the accumulated result
         computedValue = temp;
     }
-
-    @Override
-    public void visit(Function f) throws EvaluatorException {
-        CalculatorValue evaluatedArg;
-        f.arg.accept(this);
-        evaluatedArg = computedValue;
-        Class valueType = evaluatedArg.getClass();
-        CalculatorValue temp = null;
-        try {
-            Method fun = f.getClass().getMethod("apply", valueType);
-
-            temp = (CalculatorValue) fun.invoke(f,evaluatedArg);
-        } catch (NoSuchMethodException | IllegalAccessException e) {
-            e.printStackTrace();
-        } catch (InvocationTargetException e) {
-            if(e.getCause() instanceof  ArithmeticException){
-                throw new EvaluatorException("Impossible to evaluate the operation: "+e.getMessage(), f);
-            }
-            else{
-                throw new EvaluatorException("Impossible to evaluate the operation: "+e.getMessage(), f);
-            }
-        }
-        computedValue = temp;
-    }
-
-    /**
-     *
-     * @param v1 Value downcasted
-     * @param v2 Value converted to v1 Class
-     * @param o Operation to apply
-     * @return the result of the operation on v1 and v2
-     */
-    public CalculatorValue applyOp(CalculatorValue v1, CalculatorValue v2, Operation o, boolean inverted) throws ArithmeticException, InvocationTargetException {
-        Class[] arg_types = new Class[]{v1.getClass(), v1.getClass()};
-
-        String[] v1CLassName = v1.getClass().getName().split("\\.");//get the subclass name of v1
-
-        /* Generate the name of the convert method
-         * WARNING: this method must be implemented in v2 !!
-         */
-        String convertFuncName = "to"+v1CLassName[v1CLassName.length-1];
-
-        Method convertMethod = null;
-        CalculatorValue result = null;
-        try {
-            // get the convert method
-            convertMethod = v2.getClass().getMethod(convertFuncName);
-
-            //apply the opeperation on v1 and v2 that have the same type
-            //result = (CalculatorValue) o.getClass().getMethod("op", arg_types).invoke(o, v1, convertMethod.invoke(v2));
-            Method op = o.getClass().getMethod("op", arg_types);
-            if(inverted){
-                result = (CalculatorValue) op.invoke(o, convertMethod.invoke(v2), v1);
-            }else{
-                result = (CalculatorValue) op.invoke(o, v1, convertMethod.invoke(v2));
-            }
-        } catch (NoSuchMethodException | IllegalAccessException e) {
-            e.printStackTrace();
-        } catch (InvocationTargetException e) {
-            if(e.getCause() instanceof  ArithmeticException){
-                throw (ArithmeticException) e.getCause();
-            }
-            else{
-                throw e;
-            }
-        }
-        return result;
-    }
-
 }


### PR DESCRIPTION
- Move `applyOp` to new abstract Class `ComputableExpression`.
- `Function` and `Operation` classes are now childs of this new class.
- Refactor  `applyOp`: it is more general and simpler now.
- Rename  `applyOp` to `op`.